### PR TITLE
update reccommended version of nvidia driver to 396.18 due to compila…

### DIFF
--- a/nvidia/README.md
+++ b/nvidia/README.md
@@ -32,15 +32,15 @@ First, make sure you have the [Modulus code available](https://github.com/squat/
 ### Getting Started
 Enable and start the `modulus` template unit file with the desired NVIDIA version, e.g. 390.48:
 ```sh
-sudo systemctl enable modulus@nvidia-390.48
-sudo systemctl start modulus@nvidia-390.48
+sudo systemctl enable modulus@nvidia-396.18
+sudo systemctl start modulus@nvidia-396.18
 ```
 
 This service takes care of automatically compiling, installing, backing up, and loading the NVIDIA kernel modules as well as creating the NVIDIA device files.
 
 Compiling the NVIDIA kernel modules can take between 10-15 minutes depending on your Internet speed, CPU, and RAM. To check the progress of the compilation, run:
 ```sh
-journalctl -fu modulus@nvidia-390.48
+journalctl -fu modulus@nvidia-396.18
 ```
 
 ## Verify

--- a/nvidia/daemonset.yaml
+++ b/nvidia/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         args:
         - compile
         - nvidia
-        - "390.48"
+        - "396.18"
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
…tion errors on CoreOS stable (with kernel 4.16) - See: https://devtalk.nvidia.com/default/topic/1030082/linux/kernel-4-16-rc1-breaks-latest-drivers-unknown-symbol-swiotlb_map_sg_attrs-/2

fixes #10 
