### PR TITLE
Add Nvidia compatibility matrix

### DIFF
--- a/nvidia/README.md
+++ b/nvidia/README.md
@@ -102,3 +102,16 @@ Once the device plugin is running, verify that the desired nodes have allocatabl
 ```sh
 kubectl describe node <node-name>
 ```
+
+## Compatibility Matrix
+
+Here we list combinations of Flatcar Linux, Linux kernel and Nvidia versions for
+which it is known that the Nvidia modules build successfully using modulus. This
+table was created in response to Nvidia modules [failing to build on recent
+versions of Flatcar Linux in the
+past](https://github.com/squat/modulus/issues/18):
+
+| Flatcar | Kernel | Nvidia |
+|-|-|-|
+| 2605.12.0 | 5.4.92 | 440.64 |
+| 3510.2.7 | 5.15.125 | 535.104.05 |

--- a/nvidia/daemonset.yaml
+++ b/nvidia/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       hostPID: true
       initContainers:
-      - image: squat/modulus:4c946362b8267c4680618c39489d873ed386f807
+      - image: squat/modulus:6af521a148f51e164764de716da0b30769c57083
         name: modulus
         args:
         - compile

--- a/nvidia/daemonset.yaml
+++ b/nvidia/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       hostPID: true
       initContainers:
-      - image: squat/modulus:6af521a148f51e164764de716da0b30769c57083
+      - image: squat/modulus:85f9128a80cf47adea85fc008b8c2dcbfad6da86
         name: modulus
         args:
         - compile

--- a/nvidia/daemonset.yaml
+++ b/nvidia/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         args:
         - compile
         - nvidia
-        - "470.103.01"
+        - "535.104.05"
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
Thanks again for such a great tool! FYI I tried using Flatcar's native solution but I couldn't get it working so this project is still the best (and only) solution I am aware of: https://www.flatcar.org/docs/latest/setup/customization/using-nvidia/

This PR upgrades the Nvidia module version to what I have tested on my own cluster and finally closed off the following issue by creating a compatibility matrix (not sure if there is a better place/format to use though): https://github.com/squat/modulus/issues/19

Also, using the DaemonSet image in the main branch didn't work for me (see logs below) but it did work building my own image: `docker buildx build --platform linux/amd64 --push -t dippynark/modulus:custom .`

So I updated the tag to the latest commit.

I also needed the following PR for a successful build: https://github.com/squat/modulus/pull/22

Error logs for image `squat/modulus:4c946362b8267c4680618c39489d873ed386f807`:

```
nvidia 535.104.05 is out of date
Compiling kernel modules for nvidia 535.104.05, Container Linux stable amd64-usr 3510.2.7
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 21310  100 21310    0     0  56978      0 --:--:-- --:--:-- --:--:-- 56978
gpg: key E25D9AED0593B34A: "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  511M  100  511M    0     0  7214k      0  0:01:12  0:01:12 --:--:-- 8687k
gpg: Signature made Fri Sep  1 16:02:54 2023 UTC
gpg:                using RSA key E9426D8B67E35DF476BD048185F7C8868837E271
gpg:                issuer "buildbot@flatcar-linux.org"
gpg: Good signature from "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: F88C FEDE FF29 A5B4 D952  3864 E25D 9AED 0593 B34A
     Subkey fingerprint: E942 6D8B 67E3 5DF4 76BD  0481 85F7 C886 8837 E271
12640256+0 records in
12640256+0 records out
6471811072 bytes (6.5 GB, 6.0 GiB) copied, 34.9471 s, 185 MB/s
resize2fs 1.44.5 (15-Dec-2018)
Resizing the filesystem on flatcar_developer_container.bin to 2621440 (4k) blocks.
The filesystem on flatcar_developer_container.bin is now 2621440 (4k) blocks long.

Preparing environment
Cloning into '/var/lib/portage/scripts'...
Updating files: 100% (11009/11009), done.
Note: switching to 'stable-3510.2.7'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 153c9cbbfb New version: stable-3510.2.7

Performing Global Updates
(Could take a couple of minutes if you have a lot of binary packages.)


>>> Starting git clone in /var/lib/portage/scripts
>>> No submodules detected in stable-3510.2.7. Assuming unified scripts repo.
>>> Git clone in /var/lib/portage/scripts successful
>>> Symlink the repository with the appropriate folder - coreos-overlay
>>> Symlink the repository with the appropriate folder - portage-stable
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
```