### PR TITLE
Avoid resizefs missing mtab error

### DIFF
--- a/modulus
+++ b/modulus
@@ -214,7 +214,6 @@ resize_image_vol() {
     # Avoid resize2fs error: ext2fs_check_mount_point: Can't check if filesystem
     # is mounted due to missing mtab file while determining whether
     # flatcar_developer_container.bin is mounted:
-    # https://github.com/microsoft/WSL/issues/3984#issuecomment-491684299
     # https://github.com/squat/modulus/pull/24
     if [ ! -f /etc/mtab ]; then
         ln -s /proc/self/mounts /etc/mtab

--- a/modulus
+++ b/modulus
@@ -211,9 +211,8 @@ resize_image_vol() {
         exit 1
     fi
     truncate -s "$TOTAL_BYTES_FOR_IMAGE" "$IN"
-    # Avoid resize2fs error: ext2fs_check_mount_point: Can't check if filesystem
-    # is mounted due to missing mtab file while determining whether
-    # flatcar_developer_container.bin is mounted:
+    # Avoid resize2fs error: ext2fs_check_mount_point: Can't check if filesystem is mounted due to
+    # missing mtab file while determining whether flatcar_developer_container.bin is mounted:
     # https://github.com/squat/modulus/pull/24
     if [ ! -f /etc/mtab ]; then
         ln -s /proc/self/mounts /etc/mtab

--- a/modulus
+++ b/modulus
@@ -215,6 +215,7 @@ resize_image_vol() {
     # mounted due to missing mtab file while determining whether
     # flatcar_developer_container.bin is mounted:
     # https://github.com/microsoft/WSL/issues/3984#issuecomment-491684299
+    # https://github.com/squat/modulus/pull/24
     if [ ! -f /etc/mtab ]; then
         ln -s /proc/self/mounts /etc/mtab
     fi

--- a/modulus
+++ b/modulus
@@ -211,6 +211,13 @@ resize_image_vol() {
         exit 1
     fi
     truncate -s "$TOTAL_BYTES_FOR_IMAGE" "$IN"
+    # Avoid error: ext2fs_check_mount_point: Can't check if filesystem is
+    # mounted due to missing mtab file while determining whether
+    # flatcar_developer_container.bin is mounted:
+    # https://github.com/microsoft/WSL/issues/3984#issuecomment-491684299
+    if [ ! -f /etc/mtab ]; then
+        ln -s /proc/self/mounts /etc/mtab
+    fi
     resize2fs -f "$IN" "${MODULUS_IMAGE_VOLSIZE_GIB}G"
 }
 

--- a/modulus
+++ b/modulus
@@ -211,8 +211,8 @@ resize_image_vol() {
         exit 1
     fi
     truncate -s "$TOTAL_BYTES_FOR_IMAGE" "$IN"
-    # Avoid error: ext2fs_check_mount_point: Can't check if filesystem is
-    # mounted due to missing mtab file while determining whether
+    # Avoid resize2fs error: ext2fs_check_mount_point: Can't check if filesystem
+    # is mounted due to missing mtab file while determining whether
     # flatcar_developer_container.bin is mounted:
     # https://github.com/microsoft/WSL/issues/3984#issuecomment-491684299
     # https://github.com/squat/modulus/pull/24


### PR DESCRIPTION
Just ran into an error when trying to use the [latest image](https://github.com/squat/modulus/blob/727a05de7f0fe4ffbf56f52607d10a245168bf6b/nvidia/daemonset.yaml#L20). Not sure why I have not seen this before, but perhaps this is a change to Kubernetes or Flatcar Linux.

Either way, this PR should fix this issue only when required, inspired by [this](https://github.com/microsoft/WSL/issues/3984#issuecomment-491684299) comment. I have tested this on my cluster and all is working:

```
nvidia 535.104.05 is out of date
Compiling kernel modules for nvidia 535.104.05, Container Linux stable amd64-usr 3510.2.7
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 21310  100 21310    0     0  74510      0 --:--:-- --:--:-- --:--:--  160k
gpg: key E25D9AED0593B34A: "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  511M  100  511M    0     0  6221k      0  0:01:24  0:01:24 --:--:-- 9568k
gpg: Signature made Fri Sep  1 16:02:54 2023 UTC
gpg:                using RSA key E9426D8B67E35DF476BD048185F7C8868837E271
gpg:                issuer "buildbot@flatcar-linux.org"
gpg: Good signature from "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: F88C FEDE FF29 A5B4 D952  3864 E25D 9AED 0593 B34A
     Subkey fingerprint: E942 6D8B 67E3 5DF4 76BD  0481 85F7 C886 8837 E271
12640256+0 records in
12640256+0 records out
6471811072 bytes (6.5 GB, 6.0 GiB) copied, 34.1703 s, 189 MB/s
resize2fs 1.44.5 (15-Dec-2018)
ext2fs_check_mount_point: Can't check if filesystem is mounted due to missing mtab file while determining whether flatcar_developer_container.bin is mounted.
```