### PR TITLE
Use registry.k8s.io for pause container images

### DIFF
--- a/nvidia/daemonset.yaml
+++ b/nvidia/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
         - name: dev
           mountPath: /dev
       containers:
-      - image: k8s.gcr.io/pause-amd64:3.1
+      - image: registry.k8s.io/pause:3.9
         name: pause
       tolerations:
       - key: "nvidia.com/gpu"

--- a/wireguard/daemonset.yaml
+++ b/wireguard/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
         - name: dev
           mountPath: /dev
       containers:
-      - image: k8s.gcr.io/pause-amd64:3.1
+      - image: registry.k8s.io/pause:3.9
         name: pause
       tolerations:
       - key: "node-role.kubernetes.io/master"


### PR DESCRIPTION
The k8s.gcr.io registry has been deprecated: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/

This PR migrates to the registry.k8s.io registry using the default image used by the kubelet. See the `--pod-infra-container-image` flag: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/